### PR TITLE
Add possibility to configure source folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,27 @@ see below for instructions.
 ### 3. Add the *list* of `files_to_deploy` entry to your `package.json`
 
 In your `package.json` file, add the list of files & directories
-you want to be included in your distribution.
+you want to be included in your distribution. These options should be included
+in *dpl* property.
 
 Example:
 ```js
-"files_to_deploy": [ "package.json", "index.js", "lib/" ]
+"dpl": {
+  "files_to_deploy": [ "package.json", "index.js", "lib/" ]
+}
 ```
+
+If you want to deploy files which are located in a specific folder - use the *source* 
+option.
+
+Example:
+```js
+"dpl": {
+  "source": "src/"
+}
+```
+
+> ***Note***: *also you can use the both options*.
 
 ### 4. Add the deployment script to the `scripts` section in your `package.json`
 
@@ -141,7 +156,9 @@ you want to be included in your distribution.
 
 Example:
 ```js
-"files_to_deploy": [ "package.json", "index.js", "lib/" ]
+"dpl": {
+  "files_to_deploy": [ "package.json", "index.js", "lib/" ]
+}
 ```
 
 This tells `dpl` to copy these files and directory (with all contents)

--- a/lib/copy_files.js
+++ b/lib/copy_files.js
@@ -5,33 +5,50 @@ var utils = require('../lib/utils');
 var base_path = utils.get_base_path();
 var pkg = require(base_path + 'package.json');
 
-/**
- * copy_files copies the desired files & folders into the destination directory
- * @param {Array} file_list - Optional list of files & folders to be copied over
- */
-function copy_files (files_to_deploy) {
-  files_to_deploy = files_to_deploy || pkg.files_to_deploy;
-  // console.log('files_to_deploy : ', files_to_deploy);
+function copy_files () {
+  var dpl_config = pkg.dpl;
+  var source = dpl_config.source || null; // path to source folder for copy files & folders from it
+  var files_to_deploy = dpl_config.files_to_deploy;
+
   var destination = process.env.TMPDIR + 'dist/';
   mkdir_sync(destination); // ensure that the /dist directory exists
 
-  files_to_deploy.forEach(function (file_path) {
-    var fd = base_path + file_path;
-    var stat = fs.statSync(fd);
-    if (stat && stat.isFile()) {
-      var dest = destination + fd.replace(base_path, '');
-      fs.writeFileSync(dest, fs.readFileSync(fd)); // sync everywhere!!
-    } else { // the file descriptor is a directory so create it in the /dist
-      var dir = fd.replace(base_path, '') + '/'; // dir path excluding base_path
-      var dest_dir = destination + dir; // create the destination directory
-      mkdir_sync(dest_dir); // create the file before attempting to copy to it
-      // read the list of files in the directory we want to copy
-      var files = fs.readdirSync(fd);
-      var filepaths = files.map(function (f) { return dir + f; });
-      copy_files(filepaths, destination); // recurse
-    }
-  });
+  copy_all_files(files_to_deploy);
+
+  if (source) {
+    var sourceDir = fs.readdirSync(source);
+    copy_all_files(sourceDir, source);
+  }
+
+  /**
+   * copy_all_files copies the desired files & folders into the destination directory
+   * @param {Array} sdir - List of files & folders to be copied over
+   * @param {String} source - Optional path to the folder to copy all content but ignore the source folder
+   */
+  function copy_all_files (sdir, source) {
+    sdir.forEach(function (file) {
+      var bath_source_path = base_path + (source || '');
+      var fd = bath_source_path + file;
+      var stat = fs.statSync(fd);
+
+      if (stat && stat.isFile()) {
+        var dest = destination + fd.replace(bath_source_path, '');
+        fs.writeFileSync(dest, fs.readFileSync(fd)); // sync everywhere!!
+      } else { // the file descriptor is a directory so create it in the /dist
+        var dir = fd.replace(bath_source_path, '') + '/'; // directory path excluding base_path
+        var dest_dir = destination + dir; // create the destination directory
+
+        mkdir_sync(dest_dir); // create the file before attempting to copy to it
+
+        // read the list of files in the directory we want to copy
+        var files = fs.readdirSync(fd);
+        var filepaths = files.map(function (f) { return dir + f; });
+
+        copy_all_files(filepaths, source, destination);
+      }
+    });
+  }
   return;
 }
 
-module.exports = copy_files; // don't in-line this export its used recursively.
+module.exports = copy_files;

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     ]
   },
   "pre-commit": [
-    "eslint",
-    "check-coverage"
+    "eslint"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,14 @@
     "check-coverage": "npm run coverage && node_modules/.bin/istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
     "eslint": "semistandard  --verbose | snazzy"
   },
-  "files_to_deploy": [
-    "package.json",
-    "index.js",
-    "lib/"
-  ],
+  "dpl": {
+    "source": null,
+    "files_to_deploy": [
+      "package.json",
+      "index.js",
+      "lib/"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/numo-labs/aws-lambda-deploy.git"
@@ -40,6 +43,7 @@
     "mocha": "^2.4.5",
     "pre-commit": "^1.1.2",
     "semistandard": "^7.0.5",
+    "simple-mock": "^0.6.0",
     "snazzy": "^3.0.0"
   },
   "dependencies": {
@@ -47,8 +51,21 @@
   },
   "semistandard": {
     "rules": {
-      "no-multi-spaces": [2, { "exceptions": { "VariableDeclarator": true } }],
-      "brace-style":[2, "stroustrup", { "allowSingleLine": true }],
+      "no-multi-spaces": [
+        2,
+        {
+          "exceptions": {
+            "VariableDeclarator": true
+          }
+        }
+      ],
+      "brace-style": [
+        2,
+        "stroustrup",
+        {
+          "allowSingleLine": true
+        }
+      ],
       "no-trailing-spaces": 0
     },
     "globals": [
@@ -57,6 +74,7 @@
     ]
   },
   "pre-commit": [
-    "eslint"
+    "eslint",
+    "check-coverage"
   ]
 }

--- a/test/02_copy_files.test.js
+++ b/test/02_copy_files.test.js
@@ -1,11 +1,12 @@
 'use strict';
 var assert = require('assert');
 var fs = require('fs');
+var simple = require('simple-mock');
 var copy_files = require('../lib/copy_files');
 var utils = require('../lib/utils');
 var base_path = utils.get_base_path();
 var pkg = require(base_path + 'package.json');
-var files_to_deploy = pkg.files_to_deploy;
+var files_to_deploy = pkg.dpl.files_to_deploy;
 
 describe('copy_files', function () {
   it('copies the package.json file to the /dist directory', function (done) {
@@ -45,6 +46,24 @@ describe('copy_files', function () {
       // console.log(e);
     }
     assert.equal(exists, false);
+    done();
+  });
+
+  it('copy all files from "source" folder to /dist', function (done) {
+    simple.mock(require(base_path + 'package.json'), 'dpl', {
+      source: 'lib/',
+      files_to_deploy: [
+        'package.json',
+        'index.js',
+        'lib/'
+      ]
+    });
+    copy_files();
+    /** utils.js is located in lib folder */
+    var file_path = process.env.TMPDIR + 'dist/utils.js';
+    var exists = fs.statSync(file_path);
+    assert(exists);
+    simple.restore();
     done();
   });
 });


### PR DESCRIPTION
Alternative solution for https://github.com/numo-labs/aws-lambda-deploy/issues/23

If user wants to deploy files which are located in a specific folder - he should to use  source option:

```
"dpl": {
  "source": "src/",
  "files_to_deploy": [ "package.json", "config.json" ]
}
```

In the source folder can be a transpiled code, if user wants to use babel or something else.
