### PR TITLE
Prevent overwriting local .env file

### DIFF
--- a/dpl.js
+++ b/dpl.js
@@ -2,10 +2,10 @@ var start = Date.now();
 require('./test/00_env.test.js'); // check if AWS keys are set
 var dpl = require('./lib/index.js');
 var pkg = require(dpl.utils.get_base_path() + 'package.json');
+dpl.copy_files();                    // copy required files & dirs
 if (pkg.files_to_deploy.indexOf('.env') > -1) {
   dpl.utils.make_env_file(); // github.com/numo-labs/aws-lambda-deploy/issues/31
 }
-dpl.copy_files();                    // copy required files & dirs
 dpl.install_node_modules();          // install only production node_modules
 dpl.zip();                           // zip the /dist directory
 dpl.upload(function (err, data) {    // upload the .zip file to AWS:

--- a/lib/copy_files.js
+++ b/lib/copy_files.js
@@ -20,7 +20,7 @@ function copy_files (files_to_deploy) {
     // console.log('No Babel!');
   }
   files_to_deploy = files_to_deploy || pkg.files_to_deploy;
-  var destination = process.env.TMPDIR + 'dist/';
+  var destination = utils.get_target_path();
   mkdir_sync(destination); // ensure that the /dist directory exists
   files_to_deploy.forEach(function (file_path) {
     var fd = base_path + file_path;

--- a/lib/copy_files.js
+++ b/lib/copy_files.js
@@ -6,6 +6,14 @@ var base_path = utils.get_base_path();
 var path = require('path');
 var pkg = require(base_path + 'package.json');
 
+function ensure_env (files_to_deploy) {
+  const env = path.join(base_path, '.env');
+  const exists = fs.existsSync(env);
+  if (!exists && files_to_deploy.indexOf('.env') > -1) {
+    fs.writeFileSync(env, '');
+  }
+}
+
 /**
  * copy_files copies the desired files & folders into the destination directory
  * @param {Array} file_list - Optional list of files & folders to be copied over
@@ -20,6 +28,7 @@ function copy_files (files_to_deploy) {
     // console.log('No Babel!');
   }
   files_to_deploy = files_to_deploy || pkg.files_to_deploy;
+  ensure_env(files_to_deploy);
   var destination = utils.get_target_path();
   mkdir_sync(destination); // ensure that the /dist directory exists
   files_to_deploy.forEach(function (file_path) {

--- a/lib/exec_sync.js
+++ b/lib/exec_sync.js
@@ -1,25 +1,6 @@
 'use strict';
 var child_process = require('child_process');
-var fs = require('fs');
 
-function exec_sync (command) { // borrowed from shelljs
-  console.log(command);
-  // Run the command in a subshell
-  var log = ' 2>&1 1>output && echo done! > done'; // WTF is 2>&1 1> ?!?
-  // http://stackoverflow.com/questions/818255/in-the-shell-what-does-21-mean
-
-  child_process.exec(command + log); // run the command and output
-
-  // Block the event loop until the command has executed.
-  while (!fs.existsSync('done')) { // don't worry this only takes a few ms.
-  // Do nothing
-  }
-  var output = fs.readFileSync('output', 'utf8');
-  console.log(output);
-  // Delete temporary files.
-  fs.unlinkSync('output');
-  fs.unlinkSync('done');
-  return output; // in case we *want* the output log
-}
-
-module.exports = exec_sync;
+module.exports = (cmd) => {
+  return child_process.execSync(cmd, { encoding: 'utf8' });
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,15 @@ function get_base_path (start) {
 module.exports.get_base_path = get_base_path;
 
 /**
+ * get_target_path determines the target directory into which files are copied as
+ * part of the deploy process.
+ */
+function get_target_path () {
+  return process.env.TMPDIR + 'dist/';
+}
+module.exports.get_target_path = get_target_path;
+
+/**
  * delete the contents of /temp/dist so we can re-create it
  * @param dir_path {String} the path to the temporary /dist directory
  * @param remove_self {Boolean} delete the current folder if truthy.
@@ -110,5 +119,5 @@ module.exports.make_env_file = function make_env_file () {
   var env = Object.keys(process.env).map(function (k) {
     return 'export ' + k + '=' + process.env[k];
   }).join('\n');
-  return fs.writeFileSync(get_base_path() + '.env', env);
+  return fs.writeFileSync(get_target_path() + '.env', env);
 };

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -1,6 +1,6 @@
 'use strict';
 var exec_sync = require('./exec_sync'); // fs.execSync only available in v.0.12+
-var dist_path = process.env.TMPDIR + 'dist/';
+var dist_path = require('./utils').get_target_path();
 var pkg = require(require('../lib/utils').get_base_path() + 'package.json');
 var zip_file_path = process.env.TMPDIR + pkg.name + '.zip';
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
       "describe",
       "it",
       "before",
-      "after"
+      "after",
+      "afterEach"
     ]
   },
   "pre-commit": [

--- a/test/00_utils.test.js
+++ b/test/00_utils.test.js
@@ -181,8 +181,9 @@ describe('utils.description', function () {
 
 describe('utils.make_env_file', function () {
   it('create an .env file based on the current environment variables', function (done) {
+    var base = utils.get_target_path();
+    mkdir_sync(base);
     utils.make_env_file();
-    var base = utils.get_base_path();
     console.log('base_path');
     var dir = fs.readdirSync(base);
     console.log('DIR:', dir);

--- a/test/02_copy_files.test.js
+++ b/test/02_copy_files.test.js
@@ -1,14 +1,22 @@
 'use strict';
-var assert = require('assert');
-var fs = require('fs');
-var copy_files = require('../lib/copy_files');
-var utils = require('../lib/utils');
-var base_path = utils.get_base_path();
-var pkg = require(base_path + 'package.json');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const copy_files = require('../lib/copy_files');
+const utils = require('../lib/utils');
+const base_path = utils.get_base_path();
+const pkg = require(base_path + 'package.json');
 // var files_to_deploy = pkg.files_to_deploy;
 
-describe('copy_files', function () {
-  it('copies all files_to_deploy to the /dist directory', function (done) {
+describe('copy_files', () => {
+  afterEach(() => {
+    try {
+      utils.delete_dir_contents(utils.get_target_path(), true); // completely remove /dist
+    } catch (e) {
+      /* ignore */
+    }
+  });
+  it('copies all files_to_deploy to the /dist directory', (done) => {
     copy_files();
     var dist_pkg = require(process.env.TMPDIR + 'dist/package.json');
     assert.deepEqual(dist_pkg, pkg);
@@ -19,16 +27,22 @@ describe('copy_files', function () {
     done();
   });
 
-  it('delete /dist directory for next test', function (done) {
-    var dist_path = process.env.TMPDIR + 'dist';
-    var exists = false;
-    try {
-      utils.delete_dir_contents(dist_path, true); // completely remove /dist
-      exists = fs.statSync(dist_path);
-    } catch (e) {
-      // console.log(e);
-    }
-    assert.equal(exists, false);
-    done();
+  describe('if no .env file is present', () => {
+    var tmpfile;
+    const env = path.join(base_path, '.env');
+    before(() => {
+      if (fs.existsSync(env)) {
+        tmpfile = fs.readFileSync(env, 'utf8');
+        fs.unlinkSync(env);
+      }
+    });
+    after(() => {
+      fs.writeFileSync(env, tmpfile, 'utf8');
+    });
+
+    it('creates an empty .env', () => {
+      copy_files();
+      assert.equal(fs.readFileSync(env, 'utf8'), '');
+    });
   });
 });

--- a/test/04_zip.test.js
+++ b/test/04_zip.test.js
@@ -10,6 +10,16 @@ var pkg = require(base_path + 'package.json');
 var zip = require('../lib/zip');
 
 describe('zip', function () {
+  before(() => {
+    utils.delete_dir_contents(path.join(process.env.TMPDIR, 'unzipped'), true);   // delete unzipped completely
+    try { utils.clean_up(); } catch (e) {/* ignore */}
+  });
+
+  after(() => {
+    utils.delete_dir_contents(path.join(process.env.TMPDIR, 'unzipped'), true);   // delete unzipped completely
+    try { utils.clean_up(); } catch (e) {/* ignore */}
+  });
+
   it('zip the /dist directory', function (done) {
     copy_files(); // setup /dist
     install_node_modules();
@@ -25,8 +35,6 @@ describe('zip', function () {
     var unzipped = path.normalize(process.env.TMPDIR + 'unzipped');
     var unzipped_utils = require(path.normalize(unzipped + '/lib/utils'));
     assert.equal(JSON.stringify(utils), JSON.stringify(unzipped_utils));
-    utils.delete_dir_contents(unzipped, true);   // delete unzipped completely
-    utils.clean_up();
     done();
   });
 });


### PR DESCRIPTION
Write the local environment variables into the dist directory's .env file rather than the local project one. This leaves the local .env file with only the user's specific variables defined.