### PR TITLE
ensure that package.json is included in the zip uploaded to AWS.

### DIFF
--- a/lib/zip.js
+++ b/lib/zip.js
@@ -14,8 +14,6 @@ var zip_file_path = process.env.TMPDIR + pkg.name + '.zip';
 module.exports = function zip () {
   var start = process.cwd();               // get current working directory
   process.chdir(dist_path);                // change to inside the /dist dir
-  // console.log(dist_path + 'package.json');
-  require('fs').unlinkSync(dist_path + 'package.json'); // no need to zip this!
   var cmd = 'zip -rq -X ' + zip_file_path + ' ./'; // create name.zip from cwd
   exec_sync(cmd);                          // execute command synchronously
   return process.chdir(start);             // change back to original directory

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dpl",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "deploy your lambda function to AWS the quick and easy way.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
 fixes: https://github.com/numo-labs/aws-lambda-deploy/issues/47

@jruts we need this to make `lambda-taggable-createDocument` work again...