### PR TITLE
Exit with a non-zero exit code on error

### DIFF
--- a/dpl.js
+++ b/dpl.js
@@ -9,13 +9,17 @@ if (pkg.files_to_deploy.indexOf('.env') > -1) {
 dpl.install_node_modules();          // install only production node_modules
 dpl.zip();                           // zip the /dist directory
 dpl.upload(function (err, data) {    // upload the .zip file to AWS:
+  var exitcode = 0;
   if (err) {
     console.log('- - -  - - - - - - - - - - - - - - - - - - - - DEPLOY ERROR');
     console.log(err);
     console.log('- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -');
+    exitcode = 1;
+  } else {
+    console.log('- - - - - - - - > Lambda Function Deployed:');
+    console.log(data);
+    console.log('- - - - - - - - > took', (Date.now() - start) / 1000, 'seconds');
   }
-  console.log('- - - - - - - - > Lambda Function Deployed:');
-  console.log(data);
-  console.log('- - - - - - - - > took', (Date.now() - start) / 1000, 'seconds');
   dpl.utils.clean_up();              // delete /dist and .zip file for next time
+  process.exit(exitcode);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dpl",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "deploy your lambda function to AWS the quick and easy way.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Since this script is used in CI environments to deploy lambdas, it should always exit with a non-zero exit code if an error is returned by the AWS SDK so that CI jobs can report as failed.

Fixes #49 