### PR TITLE
Allow dpl to be directly referenced in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Example:
 Example:
 ```js
 "scripts": {
-	"deploy": "node ./node_modules/dpl/dpl.js"
+	"deploy": "dpl"
 }
 ```
 

--- a/dpl.js
+++ b/dpl.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 var start = Date.now();
 require('./test/00_env.test.js'); // check if AWS keys are set
 var dpl = require('./lib/index.js');

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.4.0",
   "description": "deploy your lambda function to AWS the quick and easy way.",
   "main": "lib/index.js",
+  "bin": "dpl.js",
   "scripts": {
     "nocov": "node_modules/.bin/mocha test/*.test.js",
     "test": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha --report lcov -- -R spec",


### PR DESCRIPTION
This is to allow the following in a functions `package.json`:

```
  "scripts": {
    "deploy": "dpl"
  }
```